### PR TITLE
feat: add pnpm monorepo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,53 @@ stripe.ts  fn createPaymentIntent
 (c) SearchBar  onSearch, placeholder
 ```
 
+## Monorepo Support (pnpm)
+
+If you run `ai-codex` from a pnpm monorepo root (where `pnpm-workspace.yaml` exists), it automatically:
+
+1. Discovers all workspace packages
+2. Indexes each package independently
+3. Outputs per-package subdirectories
+4. Generates a `workspace.md` overview with the internal dependency graph
+
+```bash
+# From your monorepo root
+npx ai-codex
+```
+
+Output structure:
+
+```
+.ai-codex/
+  workspace.md              # package list + internal dependency graph
+  apps/web/
+    routes.md
+    pages.md
+    lib.md
+    components.md
+  packages/shared/
+    lib.md
+    schema.md
+```
+
+### workspace.md example
+
+```
+# Workspace (generated 2026-04-02)
+# 3 packages in monorepo.
+
+## Packages
+apps/web                       @acme/web                      nextjs     routes,pages,lib,components
+packages/ui                    @acme/ui                       generic    components,lib
+packages/shared                @acme/shared                   generic    lib,schema
+
+## Internal Dependencies
+@acme/web -> @acme/ui, @acme/shared
+@acme/ui -> @acme/shared
+```
+
+To index a single package instead, just `cd` into it and run `npx ai-codex` from there.
+
 ## Integration with AI Assistants
 
 ### Claude Code
@@ -208,6 +255,7 @@ Prisma schema is auto-detected at `prisma/schema.prisma`.
 
 - Support for more frameworks (SvelteKit, Remix, Astro)
 - Support for more ORMs (Drizzle, TypeORM, Knex)
+- Support for yarn/npm workspaces
 - Watch mode (`--watch`) for continuous regeneration
 - Token count estimation in output
 - Support for Python projects (FastAPI, Django)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,563 @@
+{
+  "name": "ai-codex",
+  "version": "1.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ai-codex",
+      "version": "1.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "tsx": "^4.7.0",
+        "typescript": "^5.3.0",
+        "yaml": "^2.8.3"
+      },
+      "bin": {
+        "ai-codex": "src/generate-codex.ts"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.5.tgz",
+      "integrity": "sha512-nGsF/4C7uzUj+Nj/4J+Zt0bYQ6bz33Phz8Lb2N80Mti1HjGclTJdXZ+9APC4kLvONbjxN1zfvYNd8FEcbBK/MQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.5.tgz",
+      "integrity": "sha512-Cv781jd0Rfj/paoNrul1/r4G0HLvuFKYh7C9uHZ2Pl8YXstzvCyyeWENTFR9qFnRzNMCjXmsulZuvosDg10Mog==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.5.tgz",
+      "integrity": "sha512-Oeghq+XFgh1pUGd1YKs4DDoxzxkoUkvko+T/IVKwlghKLvvjbGFB3ek8VEDBmNvqhwuL0CQS3cExdzpmUyIrgA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.5.tgz",
+      "integrity": "sha512-nQD7lspbzerlmtNOxYMFAGmhxgzn8Z7m9jgFkh6kpkjsAhZee1w8tJW3ZlW+N9iRePz0oPUDrYrXidCPSImD0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.5.tgz",
+      "integrity": "sha512-I+Ya/MgC6rr8oRWGRDF3BXDfP8K1BVUggHqN6VI2lUZLdDi1IM1v2cy0e3lCPbP+pVcK3Tv8cgUhHse1kaNZZw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.5.tgz",
+      "integrity": "sha512-MCjQUtC8wWJn/pIPM7vQaO69BFgwPD1jriEdqwTCKzWjGgkMbcg+M5HzrOhPhuYe1AJjXlHmD142KQf+jnYj8A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.5.tgz",
+      "integrity": "sha512-X6xVS+goSH0UelYXnuf4GHLwpOdc8rgK/zai+dKzBMnncw7BTQIwquOodE7EKvY2UVUetSqyAfyZC1D+oqLQtg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.5.tgz",
+      "integrity": "sha512-233X1FGo3a8x1ekLB6XT69LfZ83vqz+9z3TSEQCTYfMNY880A97nr81KbPcAMl9rmOFp11wO0dP+eB18KU/Ucg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.5.tgz",
+      "integrity": "sha512-0wkVrYHG4sdCCN/bcwQ7yYMXACkaHc3UFeaEOwSVW6e5RycMageYAFv+JS2bKLwHyeKVUvtoVH+5/RHq0fgeFw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.5.tgz",
+      "integrity": "sha512-euKkilsNOv7x/M1NKsx5znyprbpsRFIzTV6lWziqJch7yWYayfLtZzDxDTl+LSQDJYAjd9TVb/Kt5UKIrj2e4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.5.tgz",
+      "integrity": "sha512-hVRQX4+P3MS36NxOy24v/Cdsimy/5HYePw+tmPqnNN1fxV0bPrFWR6TMqwXPwoTM2VzbkA+4lbHWUKDd5ZDA/w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.5.tgz",
+      "integrity": "sha512-mKqqRuOPALI8nDzhOBmIS0INvZOOFGGg5n1osGIXAx8oersceEbKd4t1ACNTHM3sJBXGFAlEgqM+svzjPot+ZQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.5.tgz",
+      "integrity": "sha512-EE/QXH9IyaAj1qeuIV5+/GZkBTipgGO782Ff7Um3vPS9cvLhJJeATy4Ggxikz2inZ46KByamMn6GqtqyVjhenA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.5.tgz",
+      "integrity": "sha512-0V2iF1RGxBf1b7/BjurA5jfkl7PtySjom1r6xOK2q9KWw/XCpAdtB6KNMO+9xx69yYfSCRR9FE0TyKfHA2eQMw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.5.tgz",
+      "integrity": "sha512-rYxThBx6G9HN6tFNuvB/vykeLi4VDsm5hE5pVwzqbAjZEARQrWu3noZSfbEnPZ/CRXP3271GyFk/49up2W190g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.5.tgz",
+      "integrity": "sha512-uEP2q/4qgd8goEUc4QIdU/1P2NmEtZ/zX5u3OpLlCGhJIuBIv0s0wr7TB2nBrd3/A5XIdEkkS5ZLF0ULuvaaYQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.5.tgz",
+      "integrity": "sha512-+Gq47Wqq6PLOOZuBzVSII2//9yyHNKZLuwfzCemqexqOQCSz0zy0O26kIzyp9EMNMK+nZ0tFHBZrCeVUuMs/ew==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.5.tgz",
+      "integrity": "sha512-3F/5EG8VHfN/I+W5cO1/SV2H9Q/5r7vcHabMnBqhHK2lTWOh3F8vixNzo8lqxrlmBtZVFpW8pmITHnq54+Tq4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.5.tgz",
+      "integrity": "sha512-28t+Sj3CPN8vkMOlZotOmDgilQwVvxWZl7b8rxpn73Tt/gCnvrHxQUMng4uu3itdFvrtba/1nHejvxqz8xgEMA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.5.tgz",
+      "integrity": "sha512-Doz/hKtiuVAi9hMsBMpwBANhIZc8l238U2Onko3t2xUp8xtM0ZKdDYHMnm/qPFVthY8KtxkXaocwmMh6VolzMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.5.tgz",
+      "integrity": "sha512-WfGVaa1oz5A7+ZFPkERIbIhKT4olvGl1tyzTRaB5yoZRLqC0KwaO95FeZtOdQj/oKkjW57KcVF944m62/0GYtA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.5.tgz",
+      "integrity": "sha512-Xh+VRuh6OMh3uJ0JkCjI57l+DVe7VRGBYymen8rFPnTVgATBwA6nmToxM2OwTlSvrnWpPKkrQUj93+K9huYC6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.5.tgz",
+      "integrity": "sha512-aC1gpJkkaUADHuAdQfuVTnqVUTLqqUNhAvEwHwVWcnVVZvNlDPGA0UveZsfXJJ9T6k9Po4eHi3c02gbdwO3g6w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.5.tgz",
+      "integrity": "sha512-0UNx2aavV0fk6UpZcwXFLztA2r/k9jTUa7OW7SAea1VYUhkug99MW1uZeXEnPn5+cHOd0n8myQay6TlFnBR07w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.5.tgz",
+      "integrity": "sha512-5nlJ3AeJWCTSzR7AEqVjT/faWyqKU86kCi1lLmxVqmNR+j4HrYdns+eTGjS/vmrzCIe8inGQckUadvS0+JkKdQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.5.tgz",
+      "integrity": "sha512-PWypQR+d4FLfkhBIV+/kHsUELAnMpx1bRvvsn3p+/sAERbnCzFrtDRG2Xw5n+2zPxBK2+iaP+vetsRl4Ti7WgA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.5.tgz",
+      "integrity": "sha512-zdQoHBjuDqKsvV5OPaWansOwfSQ0Js+Uj9J85TBvj3bFW1JjWTSULMRwdQAc8qMeIScbClxeMK0jlrtB9linhA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.5",
+        "@esbuild/android-arm": "0.27.5",
+        "@esbuild/android-arm64": "0.27.5",
+        "@esbuild/android-x64": "0.27.5",
+        "@esbuild/darwin-arm64": "0.27.5",
+        "@esbuild/darwin-x64": "0.27.5",
+        "@esbuild/freebsd-arm64": "0.27.5",
+        "@esbuild/freebsd-x64": "0.27.5",
+        "@esbuild/linux-arm": "0.27.5",
+        "@esbuild/linux-arm64": "0.27.5",
+        "@esbuild/linux-ia32": "0.27.5",
+        "@esbuild/linux-loong64": "0.27.5",
+        "@esbuild/linux-mips64el": "0.27.5",
+        "@esbuild/linux-ppc64": "0.27.5",
+        "@esbuild/linux-riscv64": "0.27.5",
+        "@esbuild/linux-s390x": "0.27.5",
+        "@esbuild/linux-x64": "0.27.5",
+        "@esbuild/netbsd-arm64": "0.27.5",
+        "@esbuild/netbsd-x64": "0.27.5",
+        "@esbuild/openbsd-arm64": "0.27.5",
+        "@esbuild/openbsd-x64": "0.27.5",
+        "@esbuild/openharmony-arm64": "0.27.5",
+        "@esbuild/sunos-x64": "0.27.5",
+        "@esbuild/win32-arm64": "0.27.5",
+        "@esbuild/win32-ia32": "0.27.5",
+        "@esbuild/win32-x64": "0.27.5"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -20,13 +20,16 @@
     "token-savings",
     "developer-tools",
     "nextjs",
-    "typescript"
+    "typescript",
+    "monorepo",
+    "pnpm"
   ],
   "author": "",
   "license": "MIT",
   "dependencies": {
     "tsx": "^4.7.0",
-    "typescript": "^5.3.0"
+    "typescript": "^5.3.0",
+    "yaml": "^2.8.3"
   },
   "engines": {
     "node": ">=18"

--- a/src/generate-codex.ts
+++ b/src/generate-codex.ts
@@ -13,6 +13,10 @@
  *   npx ai-codex --exclude tests dist  # skip these dirs
  *   npx ai-codex --schema prisma/schema.prisma
  *
+ * Monorepo support:
+ *   Run from a pnpm monorepo root — ai-codex auto-detects pnpm-workspace.yaml
+ *   and indexes each workspace package into per-package subdirectories.
+ *
  * Config file (codex.config.json):
  *   {
  *     "output": ".ai-codex",
@@ -24,6 +28,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import YAML from 'yaml';
 
 // ---------------------------------------------------------------------------
 // CLI Argument Parsing
@@ -112,6 +117,11 @@ Options:
 
 Config file:
   Place a codex.config.json in your project root to set defaults.
+
+Monorepo support:
+  If a pnpm-workspace.yaml is detected, ai-codex automatically indexes
+  each workspace package into per-package subdirectories and generates
+  a workspace.md overview with the internal dependency graph.
 `);
 }
 
@@ -206,7 +216,7 @@ interface FrameworkInfo {
   skipDirs: Set<string>;
 }
 
-function detectFramework(config: Config): FrameworkInfo {
+function detectFramework(config: Config, packageRoot: string): FrameworkInfo {
   const info: FrameworkInfo = {
     name: 'generic',
     appDir: null,
@@ -219,16 +229,16 @@ function detectFramework(config: Config): FrameworkInfo {
 
   // Detect Next.js
   const nextConfig = ['next.config.js', 'next.config.mjs', 'next.config.ts']
-    .find((f) => fs.existsSync(path.join(ROOT, f)));
+    .find((f) => fs.existsSync(path.join(packageRoot, f)));
   if (nextConfig) {
     info.name = 'nextjs';
     // app/ directory (App Router)
-    if (fs.existsSync(path.join(ROOT, 'app'))) {
-      info.appDir = path.join(ROOT, 'app');
+    if (fs.existsSync(path.join(packageRoot, 'app'))) {
+      info.appDir = path.join(packageRoot, 'app');
     }
     // pages/ directory (Pages Router)
-    if (fs.existsSync(path.join(ROOT, 'pages'))) {
-      info.appDir = info.appDir || path.join(ROOT, 'pages');
+    if (fs.existsSync(path.join(packageRoot, 'pages'))) {
+      info.appDir = info.appDir || path.join(packageRoot, 'pages');
     }
   }
 
@@ -237,7 +247,7 @@ function detectFramework(config: Config): FrameworkInfo {
     ? [config.schema]
     : ['prisma/schema.prisma', 'schema.prisma', 'prisma/schema/schema.prisma'];
   for (const candidate of schemaCandidates) {
-    const fullPath = path.resolve(ROOT, candidate);
+    const fullPath = path.resolve(packageRoot, candidate);
     if (fs.existsSync(fullPath)) {
       info.hasPrisma = true;
       info.prismaSchemaPath = fullPath;
@@ -248,7 +258,7 @@ function detectFramework(config: Config): FrameworkInfo {
   // Detect lib directories
   const libCandidates = ['lib', 'src/lib', 'utils', 'src/utils', 'src/helpers', 'helpers'];
   for (const dir of libCandidates) {
-    const fullPath = path.join(ROOT, dir);
+    const fullPath = path.join(packageRoot, dir);
     if (fs.existsSync(fullPath)) {
       info.libDirs.push(fullPath);
     }
@@ -257,7 +267,7 @@ function detectFramework(config: Config): FrameworkInfo {
   // Detect component directories
   const compCandidates = ['components', 'src/components', 'app/components'];
   for (const dir of compCandidates) {
-    const fullPath = path.join(ROOT, dir);
+    const fullPath = path.join(packageRoot, dir);
     if (fs.existsSync(fullPath)) {
       info.componentDirs.push(fullPath);
     }
@@ -460,18 +470,18 @@ function generatePages(framework: FrameworkInfo): string | null {
 // 3. lib.md -- Library Exports
 // ---------------------------------------------------------------------------
 
-function generateLib(framework: FrameworkInfo, config: Config): string | null {
+function generateLib(framework: FrameworkInfo, config: Config, packageRoot: string): string | null {
   // Determine which dirs to scan
   let scanDirs = framework.libDirs;
 
   // If user specified --include, scan those instead
   if (config.include.length > 0) {
-    scanDirs = config.include.map((d) => path.resolve(ROOT, d));
+    scanDirs = config.include.map((d) => path.resolve(packageRoot, d));
   }
 
   if (scanDirs.length === 0) {
     // Fallback: scan src/ if it exists
-    const srcDir = path.join(ROOT, 'src');
+    const srcDir = path.join(packageRoot, 'src');
     if (fs.existsSync(srcDir)) {
       scanDirs = [srcDir];
     } else {
@@ -500,7 +510,7 @@ function generateLib(framework: FrameworkInfo, config: Config): string | null {
       const content = readFileSafe(file);
       if (!content) continue;
 
-      const relPath = path.relative(ROOT, file);
+      const relPath = path.relative(packageRoot, file);
       const exports: LibExport[] = [];
 
       const contentLines = content.split('\n');
@@ -791,7 +801,7 @@ function generateSchema(framework: FrameworkInfo): string | null {
 // 5. components.md -- Component Index
 // ---------------------------------------------------------------------------
 
-function generateComponents(framework: FrameworkInfo): string | null {
+function generateComponents(framework: FrameworkInfo, packageRoot: string): string | null {
   const searchDirs = [...framework.componentDirs];
 
   if (searchDirs.length === 0) return null;
@@ -822,7 +832,7 @@ function generateComponents(framework: FrameworkInfo): string | null {
     if (dir.endsWith('/ui') || dir.includes('/ui/')) continue;
 
     const files = walk(dir, ['.tsx', '.jsx'], framework.skipDirs);
-    const relGroup = path.relative(ROOT, dir);
+    const relGroup = path.relative(packageRoot, dir);
 
     const components: ComponentInfo[] = [];
 
@@ -929,26 +939,26 @@ function generateComponents(framework: FrameworkInfo): string | null {
 }
 
 // ---------------------------------------------------------------------------
-// Main
+// Run generators for a single package
 // ---------------------------------------------------------------------------
 
-function main() {
-  console.log('\nai-codex -- codebase indexer for AI assistants\n');
+interface PackageResult {
+  framework: string;
+  generatedFiles: string[];
+}
 
-  const config = parseArgs();
-
-  const framework = detectFramework(config);
+function runForPackage(config: Config, packageRoot: string, outputPath: string): PackageResult {
+  const framework = detectFramework(config, packageRoot);
 
   // Merge user excludes into framework skipDirs
   for (const dir of config.exclude) {
     framework.skipDirs.add(dir);
   }
-  console.log(`  Framework:  ${framework.name}`);
-  console.log(`  Output:     ${config.output}/`);
-  if (framework.hasPrisma) console.log(`  Prisma:     ${path.relative(ROOT, framework.prismaSchemaPath!)}`);
-  console.log('');
 
-  const outputDir = path.resolve(ROOT, config.output);
+  console.log(`  Framework:  ${framework.name}`);
+  if (framework.hasPrisma) console.log(`  Prisma:     ${path.relative(packageRoot, framework.prismaSchemaPath!)}`);
+
+  const outputDir = path.resolve(ROOT, outputPath);
   try {
     fs.mkdirSync(outputDir, { recursive: true });
   } catch (err) {
@@ -959,13 +969,13 @@ function main() {
   const generators: [string, () => string | null][] = [
     ['routes.md', () => generateRoutes(framework)],
     ['pages.md', () => generatePages(framework)],
-    ['lib.md', () => generateLib(framework, config)],
+    ['lib.md', () => generateLib(framework, config, packageRoot)],
     ['schema.md', () => generateSchema(framework)],
-    ['components.md', () => generateComponents(framework)],
+    ['components.md', () => generateComponents(framework, packageRoot)],
   ];
 
   let totalLines = 0;
-  let totalFiles = 0;
+  const generatedFiles: string[] = [];
 
   for (const [filename, generator] of generators) {
     const start = Date.now();
@@ -985,7 +995,7 @@ function main() {
 
     const lineCount = content.split('\n').length;
     totalLines += lineCount;
-    totalFiles++;
+    generatedFiles.push(filename.replace('.md', ''));
 
     const outPath = path.join(outputDir, filename);
     try {
@@ -997,7 +1007,254 @@ function main() {
     console.log(`  ${pad(filename, 20)} ${pad(String(lineCount) + ' lines', 14)} (${elapsed}ms)`);
   }
 
-  console.log(`\n  Total: ${totalLines} lines across ${totalFiles} files`);
+  console.log(`  Total: ${totalLines} lines across ${generatedFiles.length} files`);
+
+  return { framework: framework.name, generatedFiles };
+}
+
+// ---------------------------------------------------------------------------
+// Workspace Discovery (pnpm)
+// ---------------------------------------------------------------------------
+
+interface WorkspacePackage {
+  name: string;
+  relPath: string;
+  absPath: string;
+  framework: string;
+  generatedFiles: string[];
+  internalDeps: string[];
+}
+
+function parsePnpmWorkspace(rootDir: string): string[] | null {
+  const wsPath = path.join(rootDir, 'pnpm-workspace.yaml');
+  if (!fs.existsSync(wsPath)) return null;
+
+  try {
+    const content = fs.readFileSync(wsPath, 'utf-8');
+    const parsed = YAML.parse(content);
+    if (parsed && Array.isArray(parsed.packages)) {
+      return parsed.packages as string[];
+    }
+    return null;
+  } catch {
+    console.warn('Warning: could not parse pnpm-workspace.yaml');
+    return null;
+  }
+}
+
+function expandWorkspaceGlobs(rootDir: string, patterns: string[]): string[] {
+  const included: string[] = [];
+  const negations: string[] = [];
+
+  for (const pattern of patterns) {
+    if (pattern.startsWith('!')) {
+      negations.push(pattern.slice(1));
+    } else {
+      included.push(pattern);
+    }
+  }
+
+  const packageDirs: string[] = [];
+
+  for (const pattern of included) {
+    // Handle simple prefix/* patterns (the vast majority of pnpm workspaces)
+    if (pattern.endsWith('/*')) {
+      const prefix = pattern.slice(0, -2);
+      const parentDir = path.join(rootDir, prefix);
+      if (!fs.existsSync(parentDir)) continue;
+      let entries: fs.Dirent[];
+      try {
+        entries = fs.readdirSync(parentDir, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        if (entry.name.startsWith('.')) continue;
+        const fullPath = path.join(parentDir, entry.name);
+        if (fs.existsSync(path.join(fullPath, 'package.json'))) {
+          packageDirs.push(fullPath);
+        }
+      }
+    } else if (pattern.includes('**')) {
+      // Recursive glob — walk looking for package.json
+      const prefix = pattern.split('**')[0];
+      const parentDir = path.join(rootDir, prefix);
+      if (!fs.existsSync(parentDir)) continue;
+      const candidates = walkForPackageJsons(parentDir);
+      for (const dir of candidates) {
+        packageDirs.push(dir);
+      }
+    } else {
+      // Exact path
+      const fullPath = path.join(rootDir, pattern);
+      if (fs.existsSync(path.join(fullPath, 'package.json'))) {
+        packageDirs.push(fullPath);
+      }
+    }
+  }
+
+  // Apply negation filters
+  if (negations.length > 0) {
+    return packageDirs.filter((dir) => {
+      const rel = path.relative(rootDir, dir);
+      return !negations.some((neg) => {
+        const negClean = neg.replace(/\*\*/g, '.*').replace(/\*/g, '[^/]*');
+        return new RegExp(`^${negClean}$`).test(rel);
+      });
+    });
+  }
+
+  // Sort for deterministic output
+  packageDirs.sort();
+  return packageDirs;
+}
+
+function walkForPackageJsons(dir: string): string[] {
+  const results: string[] = [];
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return results;
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (DEFAULT_SKIP_DIRS.has(entry.name) || entry.name.startsWith('.')) continue;
+    const full = path.join(dir, entry.name);
+    if (fs.existsSync(path.join(full, 'package.json'))) {
+      results.push(full);
+    } else {
+      for (const sub of walkForPackageJsons(full)) results.push(sub);
+    }
+  }
+  return results;
+}
+
+function readPackageName(dir: string): string {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf-8'));
+    return pkg.name || path.basename(dir);
+  } catch {
+    return path.basename(dir);
+  }
+}
+
+function resolveInternalDeps(packageDir: string, workspaceNames: Set<string>): string[] {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(packageDir, 'package.json'), 'utf-8'));
+    const allDeps = {
+      ...pkg.dependencies,
+      ...pkg.devDependencies,
+    };
+    return Object.keys(allDeps).filter((name) => workspaceNames.has(name));
+  } catch {
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// workspace.md -- Monorepo Overview
+// ---------------------------------------------------------------------------
+
+function generateWorkspace(packages: WorkspacePackage[]): string {
+  const lines: string[] = [
+    `# Workspace (generated ${TODAY})`,
+    `# ${packages.length} packages in monorepo.`,
+    '',
+    '## Packages',
+  ];
+
+  for (const pkg of packages) {
+    const files = pkg.generatedFiles.length > 0 ? pkg.generatedFiles.join(',') : '(empty)';
+    lines.push(`${pad(pkg.relPath, 30)} ${pad(pkg.name, 30)} ${pad(pkg.framework, 10)} ${files}`);
+  }
+
+  // Internal dependency graph
+  const depsEntries = packages.filter((p) => p.internalDeps.length > 0);
+  if (depsEntries.length > 0) {
+    lines.push('');
+    lines.push('## Internal Dependencies');
+    for (const pkg of depsEntries) {
+      lines.push(`${pkg.name} -> ${pkg.internalDeps.join(', ')}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main() {
+  console.log('\nai-codex -- codebase indexer for AI assistants\n');
+
+  const config = parseArgs();
+  const workspacePatterns = parsePnpmWorkspace(ROOT);
+
+  if (workspacePatterns === null) {
+    // Single-project mode (existing behaviour)
+    console.log(`  Output:     ${config.output}/`);
+    const result = runForPackage(config, ROOT, config.output);
+    console.log(`  Output: ${path.resolve(ROOT, config.output)}/`);
+    console.log('');
+    return;
+  }
+
+  // Monorepo mode
+  console.log('  Monorepo detected (pnpm-workspace.yaml)');
+  console.log(`  Output:     ${config.output}/`);
+  console.log('');
+
+  const packageDirs = expandWorkspaceGlobs(ROOT, workspacePatterns);
+  if (packageDirs.length === 0) {
+    console.log('  No workspace packages found.');
+    return;
+  }
+
+  console.log(`  Found ${packageDirs.length} packages\n`);
+
+  const packages: WorkspacePackage[] = [];
+
+  for (const pkgDir of packageDirs) {
+    const relPath = path.relative(ROOT, pkgDir);
+    const name = readPackageName(pkgDir);
+
+    console.log(`  --- ${name} (${relPath}) ---`);
+    const result = runForPackage(config, pkgDir, path.join(config.output, relPath));
+    packages.push({
+      name,
+      relPath,
+      absPath: pkgDir,
+      framework: result.framework,
+      generatedFiles: result.generatedFiles,
+      internalDeps: [],
+    });
+    console.log('');
+  }
+
+  // Resolve internal dependencies
+  const workspaceNames = new Set(packages.map((p) => p.name));
+  for (const pkg of packages) {
+    pkg.internalDeps = resolveInternalDeps(pkg.absPath, workspaceNames);
+  }
+
+  // Generate workspace overview
+  const wsContent = generateWorkspace(packages);
+  const outputDir = path.resolve(ROOT, config.output);
+  try {
+    fs.mkdirSync(outputDir, { recursive: true });
+  } catch {
+    // already exists
+  }
+  const wsPath = path.join(outputDir, 'workspace.md');
+  fs.writeFileSync(wsPath, wsContent, 'utf-8');
+  const wsLines = wsContent.split('\n').length;
+  console.log(`  ${pad('workspace.md', 20)} ${pad(String(wsLines) + ' lines', 14)}`);
+
+  const totalFiles = packages.reduce((sum, p) => sum + p.generatedFiles.length, 0) + 1;
+  console.log(`\n  Total: ${totalFiles} files across ${packages.length} packages`);
   console.log(`  Output: ${outputDir}/`);
   console.log('');
 }


### PR DESCRIPTION
## Summary
- Auto-detect `pnpm-workspace.yaml` and index each workspace package independently into per-package subdirectories
- Generate a `workspace.md` overview with package list, detected frameworks, and internal dependency graph
- Backward compatible — non-monorepo projects work identically

## Changes
- Refactored `detectFramework` and generators to accept a `packageRoot` parameter
- Added workspace discovery functions (`parsePnpmWorkspace`, `expandWorkspaceGlobs`)
- Added `workspace.md` generator with internal dependency resolution
- Added `yaml` npm dependency for robust YAML parsing
- Updated README with monorepo documentation

## Test plan
- [x] Tested single-project mode (no regression)
- [x] Tested on synthetic pnpm monorepo with 3 packages (apps/web as Next.js, packages/shared, packages/ui)
- [x] Verified per-package output structure and workspace.md content
- [ ] Test on a real pnpm monorepo codebase — routes not fully picked up yet, needs investigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)